### PR TITLE
Add hivelist collector plugin

### DIFF
--- a/plugins/base.go
+++ b/plugins/base.go
@@ -92,6 +92,9 @@ func RunVolatilityPluginAndWriteResult(args []string, resultFilepath string, isO
 			// log args with info level when running batch commands
 			cmdLogging = utils.Logger.Info
 		}
+	}
+
+	if len(resultFilepath) != 0 {
 		outputFileWriter, err := os.OpenFile(resultFilepath, GetFileOpenFlag(isOverride), 0644)
 		if err != nil {
 			return fmt.Errorf("opening %s failed: %w", resultFilepath, err)

--- a/plugins/collectors/files.go
+++ b/plugins/collectors/files.go
@@ -65,6 +65,8 @@ func (colp *FilesPlugin) Run() error {
 			Path: parts[1],
 		}
 
+		// https://github.com/volatilityfoundation/volatility3/blob/55dd39f2ba60ffdd2126b7ea011940f0df42815a/volatility3/framework/plugins/windows/poolscanner.py#L376
+		// use virtual layer for only windows 10
 		if datastore.HostInfo.MainProfile == datastore.Win10Profile {
 			fileInfo.VirtualAddrOffset = parts[0]
 		} else {

--- a/plugins/collectors/registry/hivelist.go
+++ b/plugins/collectors/registry/hivelist.go
@@ -29,10 +29,11 @@ func (colp *HiveListPlugin) Run() error {
 	}
 
 	args := []string{config.Default.VolRunConfig.Binary,
+		"-q",
 		"-f", config.Default.MemoryDumpPath,
 		"-o", colp.GetArtifactsCollectionPath(),
 		"windows.registry.hivelist.HiveList",
 		"--dump",
 	}
-	return plugins.RunVolatilityPluginAndWriteResult(args, "", true)
+	return plugins.RunVolatilityPluginAndWriteResult(args, filepath.Join(colp.GetArtifactsCollectionPath(), "hivelist.txt"), true)
 }

--- a/plugins/collectors/registry/hivelist.go
+++ b/plugins/collectors/registry/hivelist.go
@@ -1,0 +1,38 @@
+package registry
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/ImDuong/vola-auto/config"
+	"github.com/ImDuong/vola-auto/plugins"
+)
+
+type (
+	HiveListPlugin struct {
+	}
+)
+
+func (colp *HiveListPlugin) GetName() string {
+	return "HIVELIST PLUGIN"
+}
+
+func (colp *HiveListPlugin) GetArtifactsCollectionPath() string {
+	return filepath.Join(config.Default.OutputFolder, "hivelist")
+}
+
+func (colp *HiveListPlugin) Run() error {
+
+	err := os.MkdirAll(colp.GetArtifactsCollectionPath(), 0755)
+	if err != nil {
+		return err
+	}
+
+	args := []string{config.Default.VolRunConfig.Binary,
+		"-f", config.Default.MemoryDumpPath,
+		"-o", colp.GetArtifactsCollectionPath(),
+		"windows.registry.hivelist.HiveList",
+		"--dump",
+	}
+	return plugins.RunVolatilityPluginAndWriteResult(args, "", true)
+}

--- a/plugins/collectors/system32_config_hive/hive.go
+++ b/plugins/collectors/system32_config_hive/hive.go
@@ -22,6 +22,7 @@ func (colp *HivePlugin) GetName() string {
 }
 
 func (colp *HivePlugin) GetArtifactsCollectionPath() string {
+	// if there is no dumped files, can look for /collectors/registry/hivelist if such registries are present in memory image
 	return filepath.Join(config.Default.OutputFolder, "system32_config_hive")
 }
 

--- a/runner/collectors.go
+++ b/runner/collectors.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ImDuong/vola-auto/plugins/collectors/notifications"
 	"github.com/ImDuong/vola-auto/plugins/collectors/prefetch"
 	"github.com/ImDuong/vola-auto/plugins/collectors/processes"
+	"github.com/ImDuong/vola-auto/plugins/collectors/registry"
 	"github.com/ImDuong/vola-auto/plugins/collectors/sru"
 	"github.com/ImDuong/vola-auto/plugins/collectors/system32_config_hive"
 	"github.com/ImDuong/vola-auto/plugins/collectors/usnjrnl_j"
@@ -68,6 +69,7 @@ func runCollectorPlugins() error {
 		&processes.TimelinePlugin{},
 		&processes.NetworkPlugin{},
 		&processes.NetworkTimelinePlugin{},
+		&registry.HiveListPlugin{},
 	}
 
 	// empty file collector plugin to validate dumped folder


### PR DESCRIPTION
# Features
- Hivelist collector plugin: dump all hivelist based on `windows.registry.hivelist.HiveList` volatility plugin

# Improvements
- `RunVolatilityPluginAndWriteResult`: Support writing log output to a file even when dumping files